### PR TITLE
chore/renovate: Configure renovate for less noise and less usage

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["config:base"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["@inpyjamas"]
 }


### PR DESCRIPTION
The @inpyjamas config is used to make renovate create PRs less often
having so many PRs on private repos eats our quota of 3000 build minutes per month 
for private repos